### PR TITLE
Increase minimum charge

### DIFF
--- a/src/warrenapp/badelf_tools/utilities.py
+++ b/src/warrenapp/badelf_tools/utilities.py
@@ -122,7 +122,7 @@ def get_max_radius(structure: Structure, partition_file: str):
 def get_empties_from_bcf(
     directory: Path,
     structure: Structure,
-    min_charge: float = 0.1,
+    min_charge: float = 0.15,
 ):
     """
     Checks the BCF.dat output file from the Henkelman algorithm for charge


### PR DESCRIPTION
Electride search was finding too many electride sites at minimum charge of 0.1. This isn't a huge issue, but it found several points in Ti2C  that make understanding the results difficult. In the future I should probably provide a way to change this as a parameter in the input file. That way users would be able to adjust if they want more or fewer electride sites when modeling electrides similar to Ti2C.