### PR TITLE
Rework of Population Analysis HSE Workflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend= "setuptools.build_meta"
 
 [project]
 name = "warrenapp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = ["simmate"]
 description = "The Warrenapp is an extension of the Simulated Materials Ecosystem (Simmate), a package designed to ease computational materials research. The WarrenApp adds several custom workflows and settings."
 readme = "README.md"

--- a/src/warrenapp/badelf_tools/acf.py
+++ b/src/warrenapp/badelf_tools/acf.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+import pandas
+from pymatgen.io.vasp import Potcar
+from pymatgen.io.vasp.outputs import Chgcar
+
+
+def ACF(directory: Path = None, filename="ACF.dat"):
+    # grab working directory if one wasn't provided
+    if not directory:
+        directory = Path.cwd()
+
+    # convert to path obj
+    filename = directory / filename
+
+    # open the file, grab the lines, and then close it
+    with filename.open() as file:
+        lines = file.readlines()
+
+    # establish the headers. Note that I ignore the '#' column as this is
+    # just site index.
+    headers = ("x", "y", "z", "charge", "min_dist", "atomic_vol")
+
+    # create a list that we will load data into
+    bader_data = []
+    # The first 2 lines are header and the final 4 lines are the footer. This is always
+    # true so we don't need to iterate through those. The data we want is between the
+    # header and footer so that's what we loop through.
+    for line in lines[2:-4]:
+        # By running strip, we convert the line from a string to a list of
+        # The values are all still strings, so we convert them to int/floats
+        # before saving. I add [1:] because the first value is just '#' which
+        # is site index and we dont need.
+        line_data = [eval(value) for value in line.split()[1:]]
+        # add the line data to our ouput
+        bader_data.append(line_data)
+
+    # convert the list to a pandas dataframe
+    dataframe = pandas.DataFrame(
+        data=bader_data,
+        columns=headers,
+    )
+
+    # Extra data is included in the footer that we can grab too. For each line, the data
+    # is a float that is at the end of the line, hence the split()[-1].
+    extra_data = {
+        "vacuum_charge": float(lines[-3].split()[-1]),
+        "vacuum_volume": float(lines[-2].split()[-1]),
+        "nelectrons": float(lines[-1].split()[-1]),
+    }
+
+    # The remaining code is to analyze the results and calculate extra
+    # information such as the final oxidation states. This requires extra
+    # files to be present, such as from a vasp calculation
+
+    potcar_filename = directory / "POTCAR"
+    chgcar_filename = directory / "CHGCAR"
+    chgcar_empty_filename = directory / "CHGCAR_empty"  # SPECIAL CASE
+
+    # check if the required vasp files are present before doing the workup
+    if potcar_filename.exists() and (
+        chgcar_filename.exists() or chgcar_empty_filename.exists()
+    ):
+        # load the electron counts used by VASP from the POTCAR files
+        # OPTIMIZE: this can be much faster if I have a reference file
+        potcars = Potcar.from_file(potcar_filename)
+        nelectron_data = {}
+        # the result is a list because there can be multiple element potcars
+        # in the file (e.g. for NaCl, POTCAR = POTCAR_Na + POTCAR_Cl)
+        for potcar in potcars:
+            nelectron_data.update({potcar.element: potcar.nelectrons})
+
+        # SPECIAL CASE: in scenarios where empty atoms are added to the structure,
+        # we should grab that modified structure instead of the one from the POSCAR.
+        # the empty file will always take preference
+        if chgcar_empty_filename.exists():
+            chgcar = Chgcar.from_file(chgcar_empty_filename)
+            structure = chgcar.structure
+            # We typically use helium ("He") as the empty atom, so we will
+            # need to add this to our element list for oxidation analysis.
+            # We use 0 for electron count because this is an 'empty' atom, and
+            # not actually Hydrogen
+            nelectron_data.update({"He": 0})
+
+        # otherwise, grab the structure from the CHGCAR
+        # OPTIMIZE: consider grabbing from the POSCAR or CONTCAR for speed
+        else:
+            chgcar = Chgcar.from_file(chgcar_filename)
+            structure = chgcar.structure
+
+        # Calculate the oxidation state of each site where it is simply the
+        # change in number of electrons associated with it from vasp potcar vs
+        # the bader charge I also add the element strings for filtering functionality
+        elements = []
+        oxi_state_data = []
+        for site, site_charge in zip(structure, dataframe.charge.values):
+            element_str = site.specie.name
+            elements.append(element_str)
+            oxi_state = nelectron_data[element_str] - site_charge
+            oxi_state_data.append(oxi_state)
+
+        # add the new column to the dataframe
+        dataframe = dataframe.assign(
+            oxidation_state=oxi_state_data,
+            element=elements,
+        )
+        # !!! There are multiple ways to do this, but I don't know which is best
+        # dataframe["oxidation_state"] = pandas.Series(
+        #     oxi_state_data, index=dataframe.index)
+
+    return dataframe, extra_data

--- a/src/warrenapp/badelf_tools/utilities.py
+++ b/src/warrenapp/badelf_tools/utilities.py
@@ -293,7 +293,6 @@ def write_density_file_empty(
     for density_file in density_files:
         # Open CHGCAR or ELFCAR and add all of the lines past the structure info
         # to a list.
-        print("hi")
         file = open(directory / f"{density_file}", "r")
         early_lines_to_keep = []
         later_lines_to_keep = []

--- a/src/warrenapp/models.py
+++ b/src/warrenapp/models.py
@@ -3,9 +3,9 @@
 from pathlib import Path
 
 from pandas import DataFrame
-from simmate.apps.bader.outputs import ACF
 from simmate.database.base_data_types import StaticEnergy, table_column
 
+from warrenapp.badelf_tools.acf import ACF
 from warrenapp.badelf_tools.utilities import get_electride_num
 
 

--- a/src/warrenapp/workflows/__init__.py
+++ b/src/warrenapp/workflows/__init__.py
@@ -5,16 +5,21 @@ from .population_analysis import (
     PopulationAnalysis__Warren__BadelfPbe,
     PopulationAnalysis__Warren__BaderBadelfHse,
     PopulationAnalysis__Warren__BaderBadelfPbe,
+    PopulationAnalysis__Warren__BaderBadelfRelaxationHse,
+    PopulationAnalysis__Warren__BaderBadelfRelaxationPbe,
     PopulationAnalysis__Warren__BaderHse,
     PopulationAnalysis__Warren__BaderPbe,
     PopulationAnalysis__Warren__ElfHse,
     PopulationAnalysis__Warren__ElfPbe,
     StaticEnergy__Warren__PrebadelfHse,
     StaticEnergy__Warren__PrebadelfPbe,
+    StaticEnergy__Warren__PrebadelfSeededHse,
     StaticEnergy__Warren__PrebaderbadelfHse,
     StaticEnergy__Warren__PrebaderbadelfPbe,
+    StaticEnergy__Warren__PrebaderbadelfSeededHse,
     StaticEnergy__Warren__PrebaderHse,
     StaticEnergy__Warren__PrebaderPbe,
+    StaticEnergy__Warren__PrebaderSeededHse,
 )
 from .relaxation import (
     Relaxation__Warren__Hse,
@@ -31,4 +36,5 @@ from .static_energy import (
     StaticEnergy__Warren__PbeMetal,
     StaticEnergy__Warren__Pbesol,
     StaticEnergy__Warren__Scan,
+    StaticEnergy__Warren__SeededHse,
 )

--- a/src/warrenapp/workflows/population_analysis/__init__.py
+++ b/src/warrenapp/workflows/population_analysis/__init__.py
@@ -3,6 +3,7 @@
 from .badelf_hse import (
     PopulationAnalysis__Warren__BadelfHse,
     StaticEnergy__Warren__PrebadelfHse,
+    StaticEnergy__Warren__PrebadelfSeededHse,
 )
 from .badelf_pbe import (
     PopulationAnalysis__Warren__BadelfPbe,
@@ -11,14 +12,22 @@ from .badelf_pbe import (
 from .bader_badelf_hse import (
     PopulationAnalysis__Warren__BaderBadelfHse,
     StaticEnergy__Warren__PrebaderbadelfHse,
+    StaticEnergy__Warren__PrebaderbadelfSeededHse,
 )
 from .bader_badelf_pbe import (
     PopulationAnalysis__Warren__BaderBadelfPbe,
     StaticEnergy__Warren__PrebaderbadelfPbe,
 )
+from .bader_badelf_relaxation_hse import (
+    PopulationAnalysis__Warren__BaderBadelfRelaxationHse,
+)
+from .bader_badelf_relaxation_pbe import (
+    PopulationAnalysis__Warren__BaderBadelfRelaxationPbe,
+)
 from .bader_hse import (
     PopulationAnalysis__Warren__BaderHse,
     StaticEnergy__Warren__PrebaderHse,
+    StaticEnergy__Warren__PrebaderSeededHse,
 )
 from .bader_pbe import (
     PopulationAnalysis__Warren__BaderPbe,

--- a/src/warrenapp/workflows/population_analysis/badelf_hse.py
+++ b/src/warrenapp/workflows/population_analysis/badelf_hse.py
@@ -4,6 +4,7 @@ from warrenapp.workflows.population_analysis.base import (
     VaspBadElfBase,
     prebadelf_incar_settings,
 )
+from warrenapp.workflows.static_energy import StaticEnergy__Warren__SeededHse
 from warrenapp.workflows.static_energy.hse import StaticEnergy__Warren__Hse
 
 
@@ -24,6 +25,12 @@ class StaticEnergy__Warren__PrebadelfHse(StaticEnergy__Warren__Hse):
     incar.update(prebadelf_incar_settings)
 
 
+# We prefer to use a workflow that seeds the HSE calculation with a PBE calculation
+class StaticEnergy__Warren__PrebadelfSeededHse(StaticEnergy__Warren__SeededHse):
+
+    second_calculation = StaticEnergy__Warren__PrebadelfHse
+
+
 class PopulationAnalysis__Warren__BadelfHse(VaspBadElfBase):
     """
     Runs a static energy calculation using an extra-fine FFT grid and then
@@ -32,4 +39,4 @@ class PopulationAnalysis__Warren__BadelfHse(VaspBadElfBase):
     the Warren Lab.
     """
 
-    static_energy_prebadelf = StaticEnergy__Warren__PrebadelfHse
+    static_energy_prebadelf = StaticEnergy__Warren__PrebadelfSeededHse

--- a/src/warrenapp/workflows/population_analysis/bader_badelf_hse.py
+++ b/src/warrenapp/workflows/population_analysis/bader_badelf_hse.py
@@ -6,13 +6,16 @@ from warrenapp.workflows.population_analysis.base import (
     VaspBaderBadElfBase,
     prebadelf_incar_settings,
 )
-from warrenapp.workflows.static_energy import StaticEnergy__Warren__Hse
+from warrenapp.workflows.static_energy import (
+    StaticEnergy__Warren__Hse,
+    StaticEnergy__Warren__SeededHse,
+)
 
 
 class StaticEnergy__Warren__PrebaderbadelfHse(StaticEnergy__Warren__Hse):
     """
     Runs a static energy calculation with a high-density FFT grid under HSE
-    settings from the Warren Lab. Results can be used for BadLEF analysis.
+    settings from the Warren Lab. Results can be used for BadELF analysis.
 
     We do NOT recommend running this calculation on its own. Instead, you should
     use the full workflow, which runs this calculation AND the following bader
@@ -25,6 +28,13 @@ class StaticEnergy__Warren__PrebaderbadelfHse(StaticEnergy__Warren__Hse):
     incar.update(prebadelf_incar_settings)
 
 
+# We prefer to use a workflow that seeds the HSE calculation with a PBE calculation.
+# This is inherited from our static energy seeded_hse workflow.
+class StaticEnergy__Warren__PrebaderbadelfSeededHse(StaticEnergy__Warren__SeededHse):
+
+    second_calculation = StaticEnergy__Warren__PrebaderbadelfHse
+
+
 class PopulationAnalysis__Warren__BaderBadelfHse(VaspBaderBadElfBase):
     """
     Runs a static energy calculation using an extra-fine FFT grid using vasp
@@ -32,4 +42,4 @@ class PopulationAnalysis__Warren__BaderBadelfHse(VaspBaderBadElfBase):
     Uses the Warren lab settings HSE settings.
     """
 
-    static_energy_prebadelf: Workflow = StaticEnergy__Warren__PrebaderbadelfHse
+    static_energy_prebadelf: Workflow = StaticEnergy__Warren__PrebaderbadelfSeededHse

--- a/src/warrenapp/workflows/population_analysis/bader_badelf_pbe.py
+++ b/src/warrenapp/workflows/population_analysis/bader_badelf_pbe.py
@@ -26,8 +26,6 @@ class StaticEnergy__Warren__PrebaderbadelfPbe(StaticEnergy__Warren__Pbe):
     incar.update(prebadelf_incar_settings)
 
 
-# !!!I would like to move most of this to the base file because that's where
-# similar code is currently.!!!
 class PopulationAnalysis__Warren__BaderBadelfPbe(VaspBaderBadElfBase):
     """
     Runs a static energy calculation using an extra-fine FFT grid using vasp

--- a/src/warrenapp/workflows/population_analysis/bader_badelf_relaxation_hse.py
+++ b/src/warrenapp/workflows/population_analysis/bader_badelf_relaxation_hse.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from warrenapp.workflows.population_analysis import (
+    PopulationAnalysis__Warren__BaderBadelfHse,
+)
+from warrenapp.workflows.population_analysis.relaxation_base import (
+    BaderBadelfRelaxationBase,
+)
+from warrenapp.workflows.relaxation.pbesol import Relaxation__Warren__Pbesol
+
+
+# This workflow will run
+class PopulationAnalysis__Warren__BaderBadelfRelaxationHse(BaderBadelfRelaxationBase):
+    """
+    Runs a PBE quality structure relaxation, an HSE quality static energy
+    calculation (seeded with a PBE calculation), and a bader and badelf analysis.
+    """
+
+    population_analysis_workflow = PopulationAnalysis__Warren__BaderBadelfHse
+    # We use pbesol as our default relaxation functional because it doesn't take
+    # much more time than pbe and is considered to be more accurate for solids
+    # (Phys. Rev. Lett. 102, 039902 (2009))
+    relaxation_workflow = Relaxation__Warren__Pbesol

--- a/src/warrenapp/workflows/population_analysis/bader_badelf_relaxation_pbe.py
+++ b/src/warrenapp/workflows/population_analysis/bader_badelf_relaxation_pbe.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from warrenapp.workflows.population_analysis import (
+    PopulationAnalysis__Warren__BaderBadelfPbe,
+)
+from warrenapp.workflows.population_analysis.relaxation_base import (
+    BaderBadelfRelaxationBase,
+)
+from warrenapp.workflows.relaxation.pbesol import Relaxation__Warren__Pbesol
+
+
+class PopulationAnalysis__Warren__BaderBadelfRelaxationPbe(BaderBadelfRelaxationBase):
+    """
+    Runs a PBE quality structure relaxation, a PBE quality static energy
+    calculation, and a bader and badelf analysis.
+
+    """
+
+    population_analysis_workflow = PopulationAnalysis__Warren__BaderBadelfPbe
+    # We use pbesol as our default relaxation functional because it doesn't take
+    # much more time than pbe and is considered to be more accurate for solids
+    # (Phys. Rev. Lett. 102, 039902 (2009))
+    relaxation_workflow = Relaxation__Warren__Pbesol

--- a/src/warrenapp/workflows/population_analysis/bader_hse.py
+++ b/src/warrenapp/workflows/population_analysis/bader_hse.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from warrenapp.workflows.population_analysis.badelf_hse import (
-    StaticEnergy__Warren__PrebadelfHse,
-)
 from warrenapp.workflows.population_analysis.base import (
     VaspBaderBase,
     prebader_incar_settings,
 )
+from warrenapp.workflows.static_energy import StaticEnergy__Warren__SeededHse
 from warrenapp.workflows.static_energy.hse import StaticEnergy__Warren__Hse
 
 
@@ -26,6 +24,13 @@ class StaticEnergy__Warren__PrebaderHse(StaticEnergy__Warren__Hse):
     incar.update(prebader_incar_settings)
 
 
+# We prefer to use a workflow that seeds the HSE calculation with a PBE calculation.
+# This is inherited from our static energy seeded_hse workflow.
+class StaticEnergy__Warren__PrebaderSeededHse(StaticEnergy__Warren__SeededHse):
+
+    second_calculation = StaticEnergy__Warren__PrebaderHse
+
+
 class PopulationAnalysis__Warren__BaderHse(VaspBaderBase):
     """
     Runs a static energy calculation using an extra-fine FFT grid using vasp
@@ -33,4 +38,4 @@ class PopulationAnalysis__Warren__BaderHse(VaspBaderBase):
     Uses the Warren lab HSE settings.
     """
 
-    static_energy_prebader = StaticEnergy__Warren__PrebaderHse
+    static_energy_prebader = StaticEnergy__Warren__PrebaderSeededHse

--- a/src/warrenapp/workflows/population_analysis/base.py
+++ b/src/warrenapp/workflows/population_analysis/base.py
@@ -141,7 +141,7 @@ class VaspBaderBase(Workflow):
         structure: Structure,
         command: str = None,
         source: dict = None,
-        find_empties: bool = False,
+        find_empties: bool = True,
         directory: Path = None,
         **kwargs,
     ):

--- a/src/warrenapp/workflows/population_analysis/relaxation_base.py
+++ b/src/warrenapp/workflows/population_analysis/relaxation_base.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+from simmate.engine import Workflow
+from simmate.toolkit import Structure
+
+
+class BaderBadelfRelaxationBase(Workflow):
+    """
+    Base class for running a PBE quality relaxation followed by a static energy
+    and bader or badelf analysis.
+
+    This should NOT be run on its own. It is meant to be inherited from in
+    other workflows.
+    """
+
+    # We don't need to save anything from this parent workflow
+    use_database = False
+    relaxation_workflow = None  # This will be defined in inheriting workflows
+    population_analysis_workflow = None  # This will be defined in inheriting workflows
+
+    @classmethod
+    def run_config(
+        cls,
+        structure: Structure,
+        command: str = None,
+        source: dict = None,
+        find_empties: bool = True,
+        directory: Path = None,
+        **kwargs,
+    ):
+        # run a relaxation at PBE quality
+        relaxation_directory = directory / "relaxation"
+        relaxation_result = cls.relaxation_workflow.run(
+            structure=structure,
+            command=command,
+            source=source,
+            directory=relaxation_directory,
+        ).result()
+
+        static_energy_directory = directory / "static_energy"
+        # run a static energy and bader/badelf analysis using the same structure
+        # as above.
+        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        # I noticed that when I run these calculations sharing the same directory
+        # it just reruns the first calculation twice. For now I'm just moving
+        # everything to a new directory, but this shouldn't be the case. I'll
+        # contact Jack about it. This is even more cluttered with the HSE calculations
+        # which are seeded with a PBE calculation and require the same splitting
+        # of folders.
+        bader_result = cls.population_analysis_workflow.run(
+            structure=relaxation_result,
+            # copy_previous_directory = True,
+            command=command,
+            source=source,
+            find_empties=find_empties,
+            directory=static_energy_directory,
+        ).result()

--- a/src/warrenapp/workflows/static_energy/__init__.py
+++ b/src/warrenapp/workflows/static_energy/__init__.py
@@ -6,3 +6,4 @@ from .pbe import StaticEnergy__Warren__Pbe
 from .pbe_metal import StaticEnergy__Warren__PbeMetal
 from .pbesol import StaticEnergy__Warren__Pbesol
 from .scan import StaticEnergy__Warren__Scan
+from .seeded_hse import StaticEnergy__Warren__SeededHse

--- a/src/warrenapp/workflows/static_energy/pbe.py
+++ b/src/warrenapp/workflows/static_energy/pbe.py
@@ -9,7 +9,7 @@ static_settings = dict(
     LCHARG=True,
     LORBIT=11,
     LVHAR=True,
-    LWAVE=False,
+    LWAVE=True,
     ALGO="Normal",  # was "Fast" before
 )
 # These settings are saved here to make it easier to add them to other static

--- a/src/warrenapp/workflows/static_energy/pbesol.py
+++ b/src/warrenapp/workflows/static_energy/pbesol.py
@@ -7,7 +7,9 @@ from warrenapp.workflows.static_energy.pbe import static_settings
 class StaticEnergy__Warren__Pbesol(Relaxation__Warren__Pbesol):
     """
     Performs a static energy calculation based on the settings for Warren Lab
-    PBEsol functional relaxation.
+    PBEsol functional relaxation. This functional is generally considered to
+    be more accurate for solids.
+    (Phys. Rev. Lett. 102, 039902 (2009))
     """
 
     incar = Relaxation__Warren__Pbesol.incar.copy()

--- a/src/warrenapp/workflows/static_energy/seeded_hse.py
+++ b/src/warrenapp/workflows/static_energy/seeded_hse.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+import shutil
+from pathlib import Path
+
+from simmate.engine import Workflow
+from simmate.toolkit import Structure
+
+from warrenapp.workflows.static_energy import (
+    StaticEnergy__Warren__Hse,
+    StaticEnergy__Warren__Pbe,
+)
+
+
+class StaticEnergy__Warren__SeededHse(Workflow):
+    """
+    Runs an HSE quality static energy calculation seeded by a PBE static energy
+    calculation. This is sometimes necessary for HSE calculations to succeed.
+    This workflow can also be inherited fromt to create other seeded static
+    energy calculations.
+    """
+
+    # Define which workflows to use. This is so we can use this workflow in other
+    # places.
+    use_database = False
+    initial_calculation = StaticEnergy__Warren__Pbe
+    second_calculation = StaticEnergy__Warren__Hse
+
+    @classmethod
+    def run_config(
+        cls,
+        structure: Structure,
+        command: str = None,
+        source: dict = None,
+        directory: Path = None,
+        **kwargs,
+    ):
+
+        # run the initial PBE calculation and save its results as a variable
+        initial_directory = directory / "pbe_seed"
+        initial_result = cls.initial_calculation.run(
+            structure=structure,
+            command=command,
+            source=source,
+            directory=initial_directory,
+        ).result()
+
+        # We want the WAVECAR to be present for the seeded calculation so we
+        # copy it here.
+        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        # I'm not sure why, but it seems I need to create seperate
+        # directories or the nested workflow just reruns the initial calculation.
+        # Based off of Jack's documentation I don't think this should be the case.
+        # It should overwrite the previous calculation.
+        shutil.copy(initial_directory / "WAVECAR", directory)
+        # run the secondary calculation with the same structure but seperate directory
+        final_result = cls.second_calculation.run(
+            structure=initial_result,
+            command=command,
+            source=source,
+            directory=directory,
+        )


### PR DESCRIPTION
HSE workflows are now based off of a seeded static-energy calculation. There are also new population analysis workflows that run a pbe level relaxation prior to the static energy and bader/badelf steps. Also transferred acf.py output workup from the base simmate to warrenapp as it uses "H" as dummy atoms instead of "He".